### PR TITLE
Remove takealot.com

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1985,7 +1985,6 @@
 ||tags.news.com.au^$script
 ||tags.transportdirect.info^
 ||tagx.nytimes.com^
-||takealot.com/rest/
 ||talktalk.co.uk^*/log.html
 ||talktalk.co.uk^*/tracking/
 ||target.com/ci/$script


### PR DESCRIPTION
Please refer to this PR https://github.com/easylist/easylist/commit/861d6e21c9438cfed32b363c35da42b4eb6a8610#diff-99072d56e3758452bd7b56578fcdd5ac

Takealot was added to the list with no indication on the PR of the reason. We are happy to investigate and address any concerns, in the interim can you please remove us from the list as it is impacting a lot of legitimate customers.

I refer to the following https://www.takealot.com/help/terms-and-conditions and our about https://www.takealot.com/about/who-we-are